### PR TITLE
싱글톤 패턴 구현 및 디렉토리 수정

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,18 +1,23 @@
-import { PostAPI, PostAPIInterface } from './data/postAPI'
-import AccountAPI, { AccountAPIInterface } from './data/accountAPI'
+import axios from 'axios'
+import { PostAPI, PostAPIInterface } from './data/postAPI/postAPI'
+import AccountAPI, { AccountAPIInterface } from './data/accountAPI/accountAPI'
 
 export interface ContextInterface {
     postAPI: PostAPIInterface
-    signUpAPI: AccountAPIInterface
+    accountAPI: AccountAPIInterface
 }
 
 export class Context implements ContextInterface {
     postAPI
 
-    signUpAPI
+    accountAPI
 
     constructor() {
-        this.postAPI = new PostAPI()
-        this.signUpAPI = new AccountAPI()
+        const axiosInstance = axios.create({
+            baseURL: import.meta.env.VITE_API_END_POINT,
+        })
+
+        this.postAPI = PostAPI.getInstance(axiosInstance)
+        this.accountAPI = new AccountAPI()
     }
 }

--- a/src/data/accountAPI/accountAPI.ts
+++ b/src/data/accountAPI/accountAPI.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios'
-import { AccountInfo } from '../types/inedx'
+import { AccountInfo } from '../../types/account'
 import setInterceptors from './interceptor'
 
 export interface AccountAPIInterface {

--- a/src/data/accountAPI/interceptor.ts
+++ b/src/data/accountAPI/interceptor.ts
@@ -6,11 +6,9 @@ function setInterceptors(axiosInstance: AxiosInstance) {
             // 요청을 보내기 전에 어떤 처리를 할 수 있다.
             const returnConfig = config
 
-            returnConfig.baseURL = import.meta.env.VITE_API_END_POINT
             returnConfig.headers = {
-                Access_Token:
-                    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdHJpbmciLCJleHAiOjE2NzA5MDgwODgsImlhdCI6MTY3MDgyMTY4OH0.uI0oliGUKv6508PnpaBC5nuIzOghIotLKtc23jkSyWA',
-                // 테스트시 새로운 토큰으로 교체 필요
+                'Content-Type': 'application/json',
+                // 토큰 관련 로직 필요
             }
 
             return returnConfig

--- a/src/data/postAPI/interceptor.ts
+++ b/src/data/postAPI/interceptor.ts
@@ -1,0 +1,38 @@
+import { AxiosInstance } from 'axios'
+
+function setInterceptors(axiosInstance: AxiosInstance) {
+    axiosInstance.interceptors.request.use(
+        (config) => {
+            // 요청을 보내기 전에 어떤 처리를 할 수 있다.
+            const returnConfig = config
+
+            returnConfig.headers = {
+                'Content-Type': 'multipart/form-data',
+                Access_Token:
+                    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdHJpbmciLCJleHAiOjE2NzA5MDgwODgsImlhdCI6MTY3MDgyMTY4OH0.uI0oliGUKv6508PnpaBC5nuIzOghIotLKtc23jkSyWA',
+                // 테스트시 새로운 토큰으로 교체 필요
+            }
+
+            return returnConfig
+        },
+        (error) => {
+            // 요청이 잘못되었을 때 에러가 컴포넌트 단으로 오기 전에 어떤 처리를 할 수 있다.
+            return Promise.reject(error)
+        }
+    )
+
+    axiosInstance.interceptors.response.use(
+        (response) => {
+            // 서버에 요청을 보내고 나서 응답을 받기 전에 어떤 처리를 할 수 있다.
+            return response
+        },
+        (error) => {
+            // 응답이 에러인 경우에 미리 전처리할 수 있다.
+            return Promise.reject(error)
+        }
+    )
+
+    return axiosInstance
+}
+
+export default setInterceptors

--- a/src/data/postAPI/postAPI.ts
+++ b/src/data/postAPI/postAPI.ts
@@ -1,10 +1,9 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios'
-import { APIResponse, PostResponse } from '../types/response'
+import { AxiosInstance, AxiosResponse } from 'axios'
+import { APIResponse, PostResponse } from '../../types/response'
 
 import setInterceptors from './interceptor'
 
 export interface PostAPIInterface {
-    instance: AxiosInstance
     createPost: (
         payload: FormData
     ) => Promise<AxiosResponse<APIResponse<PostResponse>>>
@@ -21,16 +20,20 @@ export interface PostAPIInterface {
 }
 
 export class PostAPI implements PostAPIInterface {
-    instance
+    private axiosInstance: AxiosInstance
 
-    constructor() {
-        this.instance = setInterceptors(
-            axios.create({
-                headers: {
-                    'Content-Type': 'multipart/form-data',
-                },
-            })
-        )
+    private static instance: PostAPI
+
+    private constructor(axiosInstance: AxiosInstance) {
+        this.axiosInstance = axiosInstance
+    }
+
+    public static getInstance(axiosInstance: AxiosInstance) {
+        if (this.instance) {
+            return this.instance
+        }
+        this.instance = new PostAPI(axiosInstance)
+        return this.instance
     }
 
     /**
@@ -38,7 +41,7 @@ export class PostAPI implements PostAPIInterface {
      * 공고 작성하기
      */
     public createPost(payload: FormData) {
-        return this.instance.post('/posts', payload)
+        return setInterceptors(this.axiosInstance).post('/posts', payload)
     }
 
     /**
@@ -46,7 +49,7 @@ export class PostAPI implements PostAPIInterface {
      * 모든 공고 가져오기
      */
     public getAllPosts() {
-        return this.instance.get('/posts/all')
+        return this.axiosInstance.get('/posts/all')
     }
 
     /**
@@ -54,7 +57,7 @@ export class PostAPI implements PostAPIInterface {
      * 공고 하나 가져오기
      */
     public getOnePost(id?: string) {
-        return this.instance.get(`/posts/${id}`)
+        return this.axiosInstance.get(`/posts/${id}`)
     }
 
     /**
@@ -62,7 +65,7 @@ export class PostAPI implements PostAPIInterface {
      * 공고 업데이트하기
      */
     public updatePost(payload: FormData, id?: string) {
-        return this.instance.put(`/posts/${id}`, payload)
+        return setInterceptors(this.axiosInstance).put(`/posts/${id}`, payload)
     }
 
     /**
@@ -70,6 +73,6 @@ export class PostAPI implements PostAPIInterface {
      * 공고 지우기
      */
     public deletePost(id?: string) {
-        return this.instance.delete(`/posts/${id}`)
+        return setInterceptors(this.axiosInstance).delete(`/posts/${id}`)
     }
 }

--- a/src/types/account.d.ts
+++ b/src/types/account.d.ts
@@ -1,0 +1,5 @@
+export interface AccountInfo {
+    email: string
+    nickname?: string
+    password: string
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링
- [x] 기타

## 변경 사항
API 구조를 싱글톤 패턴에 맞게 다시 구현했습니다. 아래는 추가로 수정한 사항들입니다. 

- 공통된 axiosInstance는 context 파일에서 생성하도록 수정
- PostAPI와 AccountAPI가 사용하는 content-type이 달라 각각의 폴더에서 Interceptor를 가져오도록 수정
- accountInfo 타입 정의 파일 수정

## 기타 사항
@leeyedam 님 현재 AccountAPI와 그 구조를 공유하고 있어 수정이 필요할 것 같습니다. 번거로우실 수 있겠지만 잘 부탁드립니다. 그리고 accountInfo 타입이 정의되어있는 파일의 이름이 이미 정의되어있는 Index.d.ts 파일과 겹쳐 수정했으니 확인 부탁드립니다.

## Issue 업데이트
closes #48 